### PR TITLE
Ignoring assets generated by init command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ vendor/
 .php_cs.cache
 .DS_Store
 /.idea
+
+# Files/Dirs created by ibis init
+assets/
+content/
+export/
+ibis.php


### PR DESCRIPTION
I'm adding to gitignore files and directories typically generated with init command.